### PR TITLE
Get rid of stale dependency on scholarly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 questionary==1.5.2
-scholarly==0.3.3
 tqdm==4.47.0
 jinja2==2.11.2
 beautifulsoup4==4.9.1

--- a/webfscholar/bibtex.py
+++ b/webfscholar/bibtex.py
@@ -1,6 +1,5 @@
 """Populate local bibtex"""
 
-from scholarly import scholarly
 from webfscholar import config, profile
 from bibtexparser.bwriter import BibTexWriter
 from bibtexparser.bibdatabase import BibDatabase


### PR DESCRIPTION
Scholarly wasn't being used anymore but the package still required an old version which messes up current installs.