### PR TITLE
Explicit sort of pubs by year

### DIFF
--- a/webfscholar/__init__.py
+++ b/webfscholar/__init__.py
@@ -1,0 +1,11 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+consoleHandler = logging.StreamHandler()
+consoleHandler.setLevel(logging.WARNING)
+logger.addHandler(consoleHandler)
+
+# The arxiv package (probably) is setting some global logger settings and
+# configuring output to scholar.log. Unless you set a file logger here
+# explicitly, you're gonna inherit whatever they do.

--- a/webfscholar/web.py
+++ b/webfscholar/web.py
@@ -17,6 +17,15 @@ def add_parser(subparsers, parent):
     parser_web.add_argument('--theme', choices=THEMES.keys(), default='montserrat-badges')
 
 
+def compare_year(pub):
+    if 'year' in pub:
+        return int(pub['year'])
+    else:
+        # If there's no year, it probably isn't very important, put it at the end.
+        print("WARNING: No publication date is available, this item may not sort properly.")
+        print("\t" + pub['title'])
+        return 0
+
 def main(args):
     db = bibtex.get_bibtex(args)
     if not db.preambles:
@@ -29,6 +38,7 @@ def main(args):
     name = metadata['name']
     publications = db.entries
 
+    publications.sort(key=compare_year, reverse=True)
     for publication in publications:
         publication['author'] = publication['author'] \
             .replace(' and ', ', ') \

--- a/webfscholar/web.py
+++ b/webfscholar/web.py
@@ -3,7 +3,7 @@ from jinja2 import Template
 from pathlib import Path
 import os
 import json
-
+from . import logger
 
 PATH_OUT = 'index.html'
 PATH_TEMPLATES = Path(os.path.dirname(os.path.realpath(__file__))) / 'templates'
@@ -22,8 +22,8 @@ def compare_year(pub):
         return int(pub['year'])
     else:
         # If there's no year, it probably isn't very important, put it at the end.
-        print("WARNING: No publication date is available, this item may not sort properly.")
-        print("\t" + pub['title'])
+        logger.warning("WARNING: No publication date is available, this item may not sort properly.")
+        logger.warning("\t" + pub['title'])
         return 0
 
 def main(args):


### PR DESCRIPTION
The scraper isn't returning entries in order (the Google API seems unreliable). This adds manual sorting just to be sure.